### PR TITLE
add elixir support

### DIFF
--- a/src/ae_plugin_utils.erl
+++ b/src/ae_plugin_utils.erl
@@ -15,7 +15,7 @@ start_aecore() ->
             NodeRoot = binary_to_list(NodeRoot_),
             ErlLibs = filelib:wildcard(filename:join(NodeRoot, "lib/*/ebin")),
             AERoot = filename:join(NodeRoot, "rel/aeternity"),
-            code:add_pathsa(ErlLibs),
+            code:add_pathsz(ErlLibs),
             start_aecore(AERoot);
         _ ->
             {error, {not_set, "AE_ROOT"}}

--- a/src/ae_plugin_utils.erl
+++ b/src/ae_plugin_utils.erl
@@ -8,10 +8,18 @@
         , load_aecore/0 ]).
 
 start_aecore() ->
-    start_aecore(os:getenv("AE_ROOT")).
-
-start_aecore(false) ->
-    {error, {not_set, "AE_ROOT"}};
+    case {os:getenv("AE_ROOT"), application:get_env(ae_plugin, node_root)} of
+        {[_|_] = AERoot, _} ->
+            start_aecore(AERoot);
+        {false, {ok, <<NodeRoot_/binary>>}} ->
+            NodeRoot = binary_to_list(NodeRoot_),
+            ErlLibs = filelib:wildcard(filename:join(NodeRoot, "lib/*/ebin")),
+            AERoot = filename:join(NodeRoot, "rel/aeternity"),
+            code:add_pathsa(ErlLibs),
+            start_aecore(AERoot);
+        _ ->
+            {error, {not_set, "AE_ROOT"}}
+    end.
 start_aecore(AERoot) ->
     application:set_env(mnesia, dir, filename:join(AERoot, "data/mnesia")),
     io:fwrite("Loading aecore and deps~n", []),


### PR DESCRIPTION
Uses one config parameter - ae_plugin -> node_root to locate the top of installation (in our case _build/local) to derive other paths. 
Not versatile as when you run it for Erlang, but it's probably not needed and Elixir devs could use it via `mix` and plain config without setting env vars...