### PR TITLE
Remove need for extra copy of beam files

### DIFF
--- a/src/ae_plugin_utils.erl
+++ b/src/ae_plugin_utils.erl
@@ -16,9 +16,9 @@ start_aecore() ->
             start_aecore(AERoot);
         {false, {ok, <<NodeRoot_/binary>>}} ->
             NodeRoot = binary_to_list(NodeRoot_),
-            ErlLib = filelib:wildcard(filename:join(NodeRoot, "lib/*/ebin")),
-            ok     = code:add_pathsz(ErlLib),
             AERoot = filename:join(NodeRoot, "rel/aeternity"),
+            ErlLib = filelib:wildcard(filename:join(AERoot, "lib/*/ebin")),
+            ok     = code:add_pathsz(ErlLib),
             [SCfg] = filelib:wildcard(filename:join(AERoot, "releases/*/sys.config")),
             {ok, [AppEnvs]} = file:consult(SCfg),
             [[application:set_env(App, K, V) || {K, V} <- AppEnv] || {App, AppEnv} <- AppEnvs],


### PR DESCRIPTION
Not sure why this was needed, but MDW was forced to create an extra copy of lib/*/ebin so the ae_plugin could find the beam files. With this change we use the beam files in the untarred release directly.

This PR was sponsored by the ACF